### PR TITLE
Migate to Null safety

### DIFF
--- a/lib/sound_generator.dart
+++ b/lib/sound_generator.dart
@@ -11,22 +11,31 @@ class SoundGenerator {
       'io.github.mertguner.sound_generator/onOneCycleDataHandler');
 
   /// is Playing data changed event
-  static Stream<bool> _onIsPlayingChanged;
+  static bool _onIsPlayingChangedInitialized = false;
+  static late Stream<bool> _onIsPlayingChanged;
   static Stream<bool> get onIsPlayingChanged {
-    if (_onIsPlayingChanged == null)
+    if (!_onIsPlayingChangedInitialized) {
       _onIsPlayingChanged = _onChangeIsPlaying
           .receiveBroadcastStream()
           .map<bool>((value) => value);
+
+      _onIsPlayingChangedInitialized = true;
+    }
+      
     return _onIsPlayingChanged;
   }
 
   /// One cycle data changed event
-  static Stream<List<int>> _onGetOneCycleDataHandler;
+  static bool _onGetOneCycleDataHandlerInitialized = false;
+  static late Stream<List<int>> _onGetOneCycleDataHandler;
   static Stream<List<int>> get onOneCycleDataHandler {
-    if (_onGetOneCycleDataHandler == null)
+    if (!_onGetOneCycleDataHandlerInitialized) {
       _onGetOneCycleDataHandler = _onOneCycleDataHandler
           .receiveBroadcastStream()
           .map<List<int>>((value) => new List<int>.from(value));
+      _onGetOneCycleDataHandlerInitialized = true;
+    }
+
     return _onGetOneCycleDataHandler;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Mert Güner <m.mertguner@gmail.com>
 homepage: https://github.com/mertguner/sound_generator.git
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:

--- a/test/sound_generator_test.dart
+++ b/test/sound_generator_test.dart
@@ -9,7 +9,11 @@ void main() {
 
   setUp(() {
     channel.setMockMethodCallHandler((MethodCall methodCall) async {
-      return '42';
+      if (methodCall.method == 'isPlaying') {
+        return false;
+      }
+
+      throw ArgumentError.value(methodCall.method);
     });
   });
 
@@ -17,7 +21,7 @@ void main() {
     channel.setMockMethodCallHandler(null);
   });
 
-  test('getPlatformVersion', () async {
+  test('isPlaying should return the value from the channel', () async {
     expect(await SoundGenerator.isPlaying, false);
   });
 }


### PR DESCRIPTION
## What
Migrated the Dart to handle null safety (see https://dart.dev/null-safety).

## Why
Not supporting null safety stops any apps that are targetting SDK >= 2.12 from using the package without having to set flags. Supporting null saftey doesn't affect any backend Android/iOS specific code therefore the migration should be realtively painless from a user perspective.

## How
The streams from the sound generator now have initializer flags which allow them to be initialized late instead of to `null`.

## Testing
I have cleaned up the test that was in the test file as this was failing, but have not added any unit tests as I wasn't sure on the etiquette. I have manually tested the changes within my application without any issues.