### PR TITLE
add option to start with a clean new frequency on play()

### DIFF
--- a/android/src/main/java/io/github/mertguner/sound_generator/SoundGenerator.java
+++ b/android/src/main/java/io/github/mertguner/sound_generator/SoundGenerator.java
@@ -24,6 +24,11 @@ public class SoundGenerator {
     private int minSamplesSize;
     private WaveTypes waveType = WaveTypes.SINUSOIDAL;
     private float rightVolume = 1, leftVolume = 1;
+    private boolean cleanStart = false;
+
+    public void setCleanStart(boolean cleanStart) {
+        this.cleanStart = cleanStart;
+    }
 
     public void setAutoUpdateOneCycleSample(boolean autoUpdateOneCycleSample) {
         if (generator != null)
@@ -124,6 +129,11 @@ public class SoundGenerator {
         if (bufferThread != null || audioTrack == null) return;
 
         isPlaying = true;
+
+        if (cleanStart) {
+            generator.resetFrequency();
+            generator.updateOnce();
+        }
 
         bufferThread = new Thread(new Runnable() {
             @Override

--- a/android/src/main/java/io/github/mertguner/sound_generator/SoundGeneratorPlugin.java
+++ b/android/src/main/java/io/github/mertguner/sound_generator/SoundGeneratorPlugin.java
@@ -81,6 +81,9 @@ public class SoundGeneratorPlugin implements FlutterPlugin, MethodCallHandler {
       result.success(soundGenerator.getSampleRate());
     }else if (call.method.equals("refreshOneCycleData")) {
       soundGenerator.refreshOneCycleData();
+    }else if (call.method.equals("setCleanStart")) {
+      boolean cleanStart = call.argument("cleanStart");
+      soundGenerator.setCleanStart(cleanStart);
     }else {
       result.notImplemented();
     }

--- a/android/src/main/java/io/github/mertguner/sound_generator/generators/signalDataGenerator.java
+++ b/android/src/main/java/io/github/mertguner/sound_generator/generators/signalDataGenerator.java
@@ -52,11 +52,19 @@ public class signalDataGenerator {
         createOneCycleData();
     }
 
+    public void resetFrequency() {
+        oldFrequency = frequency;
+    }
+
     public signalDataGenerator(int bufferSamplesSize, int sampleRate) {
         this.bufferSamplesSize = bufferSamplesSize;
         backgroundBuffer = new short[bufferSamplesSize];
         buffer = new short[bufferSamplesSize];
         setSampleRate(sampleRate);
+        updateOnce();
+    }
+
+    public void updateOnce() {
         updateData();
         createOneCycleData();
     }

--- a/lib/sound_generator.dart
+++ b/lib/sound_generator.dart
@@ -110,4 +110,10 @@ class SoundGenerator {
     await _channel
         .invokeMethod("setVolume", <String, dynamic>{"volume": volume});
   }
+
+  /// Set whether we start with a clean frequency on play
+  static void setCleanStart(bool cleanStart) async {
+    await _channel
+        .invokeMethod("setCleanStart", <String, dynamic>{"cleanStart": cleanStart});
+  }
 }


### PR DESCRIPTION
Hey. This PR enables us to start with a clean new frequency when calling play(), rather than letting the sound glide smoothly to the new pitch.

For example: when we stop the generator, then change frequency, and then play again, the sound will be at the new frequency from the start, rather than gliding up to the new pitch.

I've implemented it so that it's only enabled once we set cleanStart to true through setCleanStart. But in my opinion this seems to be a saner behaviour, and it could possibly be the default. The gliding when changing frequency is very neat for changes while the sound is already playing, but it seems a bit strange if it happens when you change frequency while the sound is stopped.

Overall this certainly seems like a useful feature; to be able to play a clean tone at the desired frequency. Let me know what you think!